### PR TITLE
Decomposes tags service into `tagProvider` and `tagStore` services

### DIFF
--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -91,7 +91,7 @@ function TagEditor({
       setSuggestionsListOpen(false);
     } else {
       // Call filter() with a query value to return all matching suggestions.
-      const suggestions = tagsService.filter(pendingTag());
+      const suggestions = tagsService.filter({ text: pendingTag() });
       // Remove any repeated suggestions that are already tags
       // and set those to state.
       setSuggestions(removeDuplicates(suggestions, tagList));

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -158,7 +158,7 @@ describe('TagEditor', function () {
     wrapper.find('input').instance().value = 'tag3';
     typeInput(wrapper);
     assert.isTrue(fakeTagsService.filter.calledOnce);
-    assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
+    assert.isTrue(fakeTagsService.filter.calledWith({ text: 'tag3' }));
   });
 
   describe('suggestions open / close', () => {

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -105,6 +105,7 @@ import frameSyncService from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import localStorageService from './services/local-storage';
+import localTagsService from './services/local-tags';
 import persistedDefaultsService from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import serviceUrlService from './services/service-url';
@@ -150,6 +151,8 @@ function startApp(config, appEl) {
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', tagsService)
+    .register('tagProvider', localTagsService)
+    .register('tagStore', localTagsService)
     .register('threadsService', threadsService)
     .register('toastMessenger', ToastMessengerService)
     .register('store', store);

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,0 +1,83 @@
+/** @typedef {import('./tags').Tag} Tag */
+
+
+/**
+ * Service for fetching tag suggestions and storing data to generate them.
+ *
+ * The `tags` service stores metadata about recently used tags to local storage
+ * and provides a `filter` method to fetch tags matching a query, ranked based
+ * on frequency of usage.
+ */
+// @inject
+export default function localTags(localStorage) {
+  const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+  const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+  /**
+   * Return a list of tag suggestions matching `query`.
+   *
+   * @param {string} query
+   * @param {number|null} limit - Optional limit of the results.
+   * @return {Tag[]} List of matching tags
+   */
+  function filter(query, limit = null) {
+    const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
+    let resultCount = 0;
+    // query will match tag if:
+    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
+    // * any word in the tag starts with query
+    //   (e.g. tag "pink banana" matches query "ban"), OR
+    // * tag has substring query occurring after a non-word character
+    //   (e.g. tag "pink!banana" matches query "ban")
+    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    return savedTags.filter(tag => {
+      if (tag.match(regex)) {
+        if (limit === null || resultCount < limit) {
+          // limit allows a subset of the results
+          // See https://github.com/hypothesis/client/issues/1606
+          ++resultCount;
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Update the list of stored tag suggestions based on the tags that a user has
+   * entered for a given annotation.
+   *
+   * @param {Tag[]} tags - List of tags.
+   */
+  function store(tags) {
+    // Update the stored (tag, frequency) map.
+    const savedTags = localStorage.getObject(TAGS_MAP_KEY) || {};
+    tags.forEach(tag => {
+      if (savedTags[tag.text]) {
+        savedTags[tag.text].count += 1;
+        savedTags[tag.text].updated = Date.now();
+      } else {
+        savedTags[tag.text] = {
+          text: tag.text,
+          count: 1,
+          updated: Date.now(),
+        };
+      }
+    });
+    localStorage.setObject(TAGS_MAP_KEY, savedTags);
+
+    // Sort tag suggestions by frequency.
+    const tagsList = Object.keys(savedTags).sort((t1, t2) => {
+      if (savedTags[t1].count !== savedTags[t2].count) {
+        return savedTags[t2].count - savedTags[t1].count;
+      }
+      return t1.localeCompare(t2);
+    });
+    localStorage.setObject(TAGS_LIST_KEY, tagsList);
+  }
+
+  return {
+    filter,
+    store,
+  };
+}

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -16,11 +16,12 @@ export default function localTags(localStorage) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
+   * @async
    * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
-   * @return {Tag[]} List of matching tags
+   * @return {Promise<Tag[]>} List of matching tags
    */
-  function filter(query, limit = null) {
+  async function filter(query, limit = null) {
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
     // query will match tag if:
@@ -30,7 +31,7 @@ export default function localTags(localStorage) {
     // * tag has substring query occurring after a non-word character
     //   (e.g. tag "pink!banana" matches query "ban")
     let regex = new RegExp('(\\W|\\b)' + query.text, 'i');
-    return savedTags.filter(tag => {
+    let suggestions = savedTags.filter(tag => {
       if (tag.match(regex)) {
         if (limit === null || resultCount < limit) {
           // limit allows a subset of the results
@@ -41,15 +42,19 @@ export default function localTags(localStorage) {
       }
       return false;
     });
+
+    return Promise.resolve(suggestions);
   }
 
   /**
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
+   * @async
    * @param {Tag[]} tags - List of tags.
+   * @return {Promise}
    */
-  function store(tags) {
+  async function store(tags) {
     // Update the stored (tag, frequency) map.
     const savedTags = localStorage.getObject(TAGS_MAP_KEY) || {};
     tags.forEach(tag => {
@@ -74,6 +79,8 @@ export default function localTags(localStorage) {
       return t1.localeCompare(t2);
     });
     localStorage.setObject(TAGS_LIST_KEY, tagsList);
+
+    return Promise.resolve();
   }
 
   return {

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,4 +1,5 @@
 /** @typedef {import('./tags').Tag} Tag */
+/** @typedef {import('./tags').TagQuery} TagQuery */
 
 /**
  * Service for fetching tag suggestions and storing data to generate them.
@@ -15,7 +16,7 @@ export default function localTags(localStorage) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
-   * @param {string} query
+   * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
@@ -28,7 +29,7 @@ export default function localTags(localStorage) {
     //   (e.g. tag "pink banana" matches query "ban"), OR
     // * tag has substring query occurring after a non-word character
     //   (e.g. tag "pink!banana" matches query "ban")
-    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    let regex = new RegExp('(\\W|\\b)' + query.text, 'i');
     return savedTags.filter(tag => {
       if (tag.match(regex)) {
         if (limit === null || resultCount < limit) {

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,6 +1,5 @@
 /** @typedef {import('./tags').Tag} Tag */
 
-
 /**
  * Service for fetching tag suggestions and storing data to generate them.
  *

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -26,11 +26,12 @@ export default function tags(tagProvider, tagStore) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
+   * @async
    * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
-   * @return {Tag[]} List of matching tags
+   * @return {Promise<Tag[]>} List of matching tags
    */
-  function filter(query, limit = null) {
+  async function filter(query, limit = null) {
     return tagProvider.filter(query, limit);
   }
 
@@ -38,9 +39,11 @@ export default function tags(tagProvider, tagStore) {
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
+   * @async
    * @param {Tag[]} tags - List of tags.
+   * @return {Promise}
    */
-  function store(tags) {
+  async function store(tags) {
     return tagStore.store(tags);
   }
 

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -6,8 +6,14 @@
  */
 
 /**
+ * @typedef TagQuery
+ * @property {string} text - The text entered in the tag editor
+ * @property {object|null} context - Optional context object.
+ */
+
+/**
  * Service for fetching tag suggestions from a tagProvider service
- * and storing data for future suggestions.
+ * and optionally storing data to generate them.
  *
  * The injected `tagProvider` service needs to provide `filter` method to
  * fetch tag suggestions matching a query and optional context object.
@@ -20,7 +26,7 @@ export default function tags(tagProvider, tagStore) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
-   * @param {string} query
+   * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -5,7 +5,6 @@
  * @property {number} updated - The timestamp when this tag was last used.
  */
 
-
 /**
  * Service for fetching tag suggestions from a tagProvider service
  * and storing data for future suggestions.
@@ -18,7 +17,6 @@
  */
 // @inject
 export default function tags(tagProvider, tagStore) {
-
   /**
    * Return a list of tag suggestions matching `query`.
    *
@@ -26,8 +24,7 @@ export default function tags(tagProvider, tagStore) {
    * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
-  function filter(query,
-                  limit = null) {
+  function filter(query, limit = null) {
     return tagProvider.filter(query, limit);
   }
 

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -66,30 +66,29 @@ describe('sidebar/services/tag-provider', () => {
   });
 
   describe('#filter', () => {
-    it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter({ text: 'b' }), [
-        'bar',
-        'bar argon',
-        'banana',
-      ]);
+    it('returns tags that start with the query string', async () => {
+      let suggestions = await tags.filter({ text: 'b' });
+      assert.deepEqual(suggestions, ['bar', 'bar argon', 'banana']);
     });
 
-    it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter({ text: 'ar' }), ['bar argon', 'argon']);
+    it('returns tags that have any word starting with the query string', async () => {
+      let suggestions = await tags.filter({ text: 'ar' });
+      assert.deepEqual(suggestions, ['bar argon', 'argon']);
     });
 
-    it('is case insensitive', () => {
-      assert.deepEqual(tags.filter({ text: 'Ar' }), ['bar argon', 'argon']);
+    it('is case insensitive', async () => {
+      let suggestions = await tags.filter({ text: 'Ar' });
+      assert.deepEqual(suggestions, ['bar argon', 'argon']);
     });
 
-    it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter({ text: 'b' }, 1), ['bar']);
-      assert.deepEqual(tags.filter({ text: 'b' }, 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter({ text: 'b' }, 3), [
-        'bar',
-        'bar argon',
-        'banana',
-      ]);
+    it('limits tags when provided a limit value', async () => {
+      let one = await tags.filter({ text: 'b' }, 1);
+      let two = await tags.filter({ text: 'b' }, 2);
+      let tre = await tags.filter({ text: 'b' }, 3);
+
+      assert.deepEqual(one, ['bar']);
+      assert.deepEqual(two, ['bar', 'bar argon']);
+      assert.deepEqual(tre, ['bar', 'bar argon', 'banana']);
     });
   });
 });

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -1,0 +1,87 @@
+import tagProviderFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-provider', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagProviderFactory(fakeLocalStorage);
+  });
+
+  describe('#filter', () => {
+    it('returns tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+    });
+
+    it('returns tags that have any word starting with the query string', () => {
+      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
+    });
+
+    it('is case insensitive', () => {
+      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
+    });
+
+    it('limits tags when provided a limit value', () => {
+      assert.deepEqual(tags.filter('b', 1), ['bar']);
+      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    });
+  });
+});

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -67,21 +67,29 @@ describe('sidebar/services/tag-provider', () => {
 
   describe('#filter', () => {
     it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+      assert.deepEqual(tags.filter({ text: 'b' }), [
+        'bar',
+        'bar argon',
+        'banana',
+      ]);
     });
 
     it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
+      assert.deepEqual(tags.filter({ text: 'ar' }), ['bar argon', 'argon']);
     });
 
     it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
+      assert.deepEqual(tags.filter({ text: 'Ar' }), ['bar argon', 'argon']);
     });
 
     it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('b', 1), ['bar']);
-      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 1), ['bar']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 3), [
+        'bar',
+        'bar argon',
+        'banana',
+      ]);
     });
   });
 });

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -1,0 +1,108 @@
+import tagStoreFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-store', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagStoreFactory(fakeLocalStorage);
+  });
+
+  describe('#store', () => {
+    it('saves new tags to storage', () => {
+      tags.store([{ text: 'new' }]);
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.include(storedTagsList, 'new');
+
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.match(
+        storedTagsMap.new,
+        sinon.match({
+          count: 1,
+          text: 'new',
+          updated: sinon.match.number,
+        })
+      );
+    });
+
+    it('increases the count for a tag already stored', () => {
+      tags.store([{ text: 'bar' }]);
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.equal(storedTagsMap.bar.count, 6);
+    });
+
+    it('orders list by count descending, lexical ascending', () => {
+      for (let i = 0; i < 6; i++) {
+        tags.store([{ text: 'foo' }]);
+      }
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.deepEqual(storedTagsList, [
+        'foo',
+        'bar',
+        'banana',
+        'bar argon',
+        'future',
+        'argon',
+      ]);
+    });
+  });
+});

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -66,8 +66,8 @@ describe('sidebar/services/tag-store', () => {
   });
 
   describe('#store', () => {
-    it('saves new tags to storage', () => {
-      tags.store([{ text: 'new' }]);
+    it('saves new tags to storage', async () => {
+      await tags.store([{ text: 'new' }]);
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
       assert.include(storedTagsList, 'new');
@@ -83,15 +83,15 @@ describe('sidebar/services/tag-store', () => {
       );
     });
 
-    it('increases the count for a tag already stored', () => {
-      tags.store([{ text: 'bar' }]);
+    it('increases the count for a tag already stored', async () => {
+      await tags.store([{ text: 'bar' }]);
       const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
       assert.equal(storedTagsMap.bar.count, 6);
     });
 
-    it('orders list by count descending, lexical ascending', () => {
+    it('orders list by count descending, lexical ascending', async () => {
       for (let i = 0; i < 6; i++) {
-        tags.store([{ text: 'foo' }]);
+        await tags.store([{ text: 'foo' }]);
       }
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -32,7 +32,13 @@ describe('sidebar/services/tags', () => {
 
   describe('#filter', () => {
     it('delegates query call to tag-provider', () => {
-      let query = 'pourquoi';
+      let query = { text: 'pourquoi' };
+      tags.filter(query);
+      return assert.calledWith(fakeTagProvider.filter, query);
+    });
+
+    it('delegates query call to tag-provider with sample context', () => {
+      let query = { text: 'pourquoi', context: { lang: 'fr' } };
       tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,128 +1,48 @@
 import tagsFactory from '../tags';
+import { Injector } from '../../../shared/injector';
 
-const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
-const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
-
-class FakeStorage {
-  constructor() {
-    this._storage = {};
-  }
-
-  getObject(key) {
-    return this._storage[key];
-  }
-
-  setObject(key, value) {
-    this._storage[key] = value;
-  }
-}
+let fakeTagProvider;
+let fakeTagStore;
+let sandbox;
 
 describe('sidebar/services/tags', () => {
-  let fakeLocalStorage;
   let tags;
 
   beforeEach(() => {
-    fakeLocalStorage = new FakeStorage();
+    sandbox = sinon.createSandbox();
 
-    const stamp = Date.now();
-    const savedTagsMap = {
-      foo: {
-        text: 'foo',
-        count: 1,
-        updated: stamp,
-      },
-      bar: {
-        text: 'bar',
-        count: 5,
-        updated: stamp,
-      },
-      'bar argon': {
-        text: 'bar argon',
-        count: 2,
-        updated: stamp,
-      },
-      banana: {
-        text: 'banana',
-        count: 2,
-        updated: stamp,
-      },
-      future: {
-        text: 'future',
-        count: 2,
-        updated: stamp,
-      },
-      argon: {
-        text: 'argon',
-        count: 1,
-        updated: stamp,
-      },
+    fakeTagProvider = {
+      filter: sinon.stub()
     };
-    const savedTagsList = Object.keys(savedTagsMap);
 
-    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
-    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+    fakeTagStore = {
+      store: sinon.stub()
+    };
 
-    tags = tagsFactory(fakeLocalStorage);
+    tags = new Injector()
+      .register('tagProvider', { value: fakeTagProvider })
+      .register('tagStore', { value: fakeTagStore })
+      .register( 'tags', tagsFactory)
+      .get('tags');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   describe('#filter', () => {
-    it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
-    });
-
-    it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
-    });
-
-    it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
-    });
-
-    it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('b', 1), ['bar']);
-      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    it('delegates query call to tag-provider', () => {
+      let query = 'pourquoi';
+      tags.filter(query);
+      return assert.calledWith(fakeTagProvider.filter, query);
     });
   });
 
   describe('#store', () => {
-    it('saves new tags to storage', () => {
-      tags.store([{ text: 'new' }]);
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.include(storedTagsList, 'new');
-
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.match(
-        storedTagsMap.new,
-        sinon.match({
-          count: 1,
-          text: 'new',
-          updated: sinon.match.number,
-        })
-      );
-    });
-
-    it('increases the count for a tag already stored', () => {
-      tags.store([{ text: 'bar' }]);
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.equal(storedTagsMap.bar.count, 6);
-    });
-
-    it('orders list by count descending, lexical ascending', () => {
-      for (let i = 0; i < 6; i++) {
-        tags.store([{ text: 'foo' }]);
-      }
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.deepEqual(storedTagsList, [
-        'foo',
-        'bar',
-        'banana',
-        'bar argon',
-        'future',
-        'argon',
-      ]);
+    it('delegates store call to tag-store', () => {
+      let theTags = [{ text: 'parce que' }];
+      tags.store(theTags);
+      return assert.calledWith(fakeTagStore.store, theTags);
     });
   });
 });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -12,17 +12,17 @@ describe('sidebar/services/tags', () => {
     sandbox = sinon.createSandbox();
 
     fakeTagProvider = {
-      filter: sinon.stub()
+      filter: sinon.stub(),
     };
 
     fakeTagStore = {
-      store: sinon.stub()
+      store: sinon.stub(),
     };
 
     tags = new Injector()
       .register('tagProvider', { value: fakeTagProvider })
       .register('tagStore', { value: fakeTagStore })
-      .register( 'tags', tagsFactory)
+      .register('tags', tagsFactory)
       .get('tags');
   });
 

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -31,23 +31,23 @@ describe('sidebar/services/tags', () => {
   });
 
   describe('#filter', () => {
-    it('delegates query call to tag-provider', () => {
+    it('delegates query call to tag-provider', async () => {
       let query = { text: 'pourquoi' };
-      tags.filter(query);
+      await tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });
 
-    it('delegates query call to tag-provider with sample context', () => {
+    it('delegates query call to tag-provider with sample context', async () => {
       let query = { text: 'pourquoi', context: { lang: 'fr' } };
-      tags.filter(query);
+      await tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });
   });
 
   describe('#store', () => {
-    it('delegates store call to tag-store', () => {
+    it('delegates store call to tag-store', async () => {
       let theTags = [{ text: 'parce que' }];
-      tags.store(theTags);
+      await tags.store(theTags);
       return assert.calledWith(fakeTagStore.store, theTags);
     });
   });

--- a/src/test-util/accessibility.js
+++ b/src/test-util/accessibility.js
@@ -72,7 +72,7 @@ export function checkAccessibility(scenarios) {
         );
       }
 
-      const elementOrWrapper = content();
+      const elementOrWrapper = await content();
 
       if (
         !(elementOrWrapper instanceof ReactWrapper) &&


### PR DESCRIPTION
This is in preparation for simpler customization of `tagProvider`
services beyond the current cache implemented in localStorage.

- The tag service now injects a tagProvider and tagStore
- The localStorage implementation has moved to local-tags.js
- local-tags.js is now injected back as *both* tagProvider and tagStore.

(Preserves existing functionality in client)