### PR TITLE
Decomposes `tagService` into `tagProvider` and `tagStore` services

### DIFF
--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -74,8 +74,17 @@ function AnnotationEditor({
       return false;
     }
     const tagList = [...tags, newTag];
+
     // Update the tag locally for the suggested-tag list
-    tagsService.store(tagList);
+    const listOfTag = tagList.map(t => {
+      return {
+        text: t,
+        count: 1,
+        updated: Date.now(),
+      };
+    });
+    tagsService.store(listOfTag);
+
     onEditTags({ tags: tagList });
     return true;
   };

--- a/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
+++ b/src/sidebar/components/Annotation/test/AnnotationEditor-test.js
@@ -104,7 +104,7 @@ describe('AnnotationEditor', () => {
         const storeCall = fakeTagsService.store.getCall(0);
         const draftCall = fakeStore.createDraft.getCall(0);
 
-        assert.deepEqual(storeCall.args[0], ['newTag']);
+        assert.equal(storeCall.args[0][0].text, 'newTag');
         assert.deepEqual(draftCall.args[1].tags, ['newTag']);
       });
 

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -91,7 +91,7 @@ function TagEditor({
       setSuggestionsListOpen(false);
     } else {
       // Call filter() with a query value to return all matching suggestions.
-      const suggestions = tagsService.filter(pendingTag());
+      const suggestions = tagsService.filter({ text: pendingTag() });
       // Remove any repeated suggestions that are already tags
       // and set those to state.
       setSuggestions(removeDuplicates(suggestions, tagList));

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -10,6 +10,7 @@ import { withServices } from '../service-context';
 import AutocompleteList from './AutocompleteList';
 
 /** @typedef {import("preact").JSX.Element} JSXElement */
+/** @typedef {import("../services/tags").Tag} Tag */
 
 // Global counter used to create a unique id for each instance of a TagEditor
 let tagEditorIdCounter = 0;
@@ -19,6 +20,7 @@ let tagEditorIdCounter = 0;
  * @prop {(tag: string) => boolean} onAddTag - Callback to add a tag to the annotation
  * @prop {(tag: string) => boolean} onRemoveTag - Callback to remove a tag from the annotation
  * @prop {(tag: string) => any} onTagInput - Callback when inputted tag text changes
+ * @prop {(tags: Tag[]) => any} onTagSuggestions - Callback when suggestions returned
  * @prop {string[]} tagList - The list of tags for the annotation under edit
  * @prop {import('../services/tags').TagsService} tags
  */
@@ -35,6 +37,7 @@ function TagEditor({
   onAddTag,
   onRemoveTag,
   onTagInput,
+  onTagSuggestions,
   tagList,
   tags: tagsService,
 }) {
@@ -85,18 +88,21 @@ function TagEditor({
    * Get a list of suggestions returned from the tagsService
    * reset the activeItem and open the AutocompleteList
    */
-  const updateSuggestions = () => {
+  const updateSuggestions = async () => {
+    let uniqueSuggestions = [];
     if (!hasPendingTag()) {
       // If there is no input, just hide the suggestions
       setSuggestionsListOpen(false);
     } else {
       // Call filter() with a query value to return all matching suggestions.
-      const suggestions = tagsService.filter({ text: pendingTag() });
+      const suggestions = await tagsService.filter({ text: pendingTag() });
       // Remove any repeated suggestions that are already tags
       // and set those to state.
-      setSuggestions(removeDuplicates(suggestions, tagList));
-      setSuggestionsListOpen(suggestions.length > 0);
+      const uniqueSuggestions = removeDuplicates(suggestions, tagList);
+      setSuggestions(uniqueSuggestions);
+      setSuggestionsListOpen(uniqueSuggestions.length > 0);
     }
+    onTagSuggestions?.(uniqueSuggestions);
     setActiveItem(-1);
   };
 
@@ -116,9 +122,9 @@ function TagEditor({
     }
   };
 
-  const handleOnInput = () => {
+  const handleOnInput = async () => {
     onTagInput?.(pendingTag());
-    updateSuggestions();
+    return updateSuggestions();
   };
 
   /**

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -95,7 +95,11 @@ function TagEditor({
       setSuggestionsListOpen(false);
     } else {
       // Call filter() with a query value to return all matching suggestions.
-      const suggestions = await tagsService.filter({ text: pendingTag() });
+      const tags = await tagsService.filter({ text: pendingTag() });
+
+      // TRANSFORM (Tag -> string): extract the text fields, removing any empty strings
+      const suggestions = tags.map(t => t.text).filter(s => s);
+
       // Remove any repeated suggestions that are already tags
       // and set those to state.
       const uniqueSuggestions = removeDuplicates(suggestions, tagList);

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -158,7 +158,7 @@ describe('TagEditor', function () {
     wrapper.find('input').instance().value = 'tag3';
     typeInput(wrapper);
     assert.isTrue(fakeTagsService.filter.calledOnce);
-    assert.isTrue(fakeTagsService.filter.calledWith('tag3'));
+    assert.isTrue(fakeTagsService.filter.calledWith({ text: 'tag3' }));
   });
 
   describe('suggestions open / close', () => {

--- a/src/sidebar/components/test/TagEditor-test.js
+++ b/src/sidebar/components/test/TagEditor-test.js
@@ -48,7 +48,7 @@ describe('TagEditor', function () {
     fakeOnTagInput = sinon.stub();
     fakeServiceUrl = sinon.stub().returns('http://serviceurl.com');
     fakeTagsService = {
-      filter: sinon.stub().resolves(['tag4', 'tag3']),
+      filter: sinon.stub().resolves([{ text: 'tag4' }, { text: 'tag3' }]),
     };
     fakeOnTagSuggestions = sinon.stub();
     $imports.$mock(mockImportedComponents());
@@ -114,7 +114,10 @@ describe('TagEditor', function () {
   });
 
   it('shows case-insensitive matches to suggested tags', async () => {
-    fakeTagsService.filter.resolves(['fine AArdvark', 'AAArgh']);
+    fakeTagsService.filter.resolves([
+      { text: 'fine AArdvark' },
+      { text: 'AAArgh' },
+    ]);
     const wrapper = createComponent();
     wrapper.find('input').instance().value = 'aa';
     await typeInputAndAwaitResponse(wrapper);
@@ -143,7 +146,10 @@ describe('TagEditor', function () {
     // "matching" as the component, so we should be able to handle cases where
     // there doesn't "seem" to be a match by just rendering the suggested tag
     // as-is.
-    fakeTagsService.filter.resolves(['fine AArdvark', 'AAArgh']);
+    fakeTagsService.filter.resolves([
+      { text: 'fine AArdvark' },
+      { text: 'AAArgh' },
+    ]);
     const wrapper = createComponent();
     wrapper.find('input').instance().value = 'bb';
     await typeInputAndAwaitResponse(wrapper);
@@ -380,7 +386,7 @@ describe('TagEditor', function () {
 
       it('should add the suggested tag when there is exactly one suggestion', async () => {
         const wrapper = createComponent();
-        fakeTagsService.filter.resolves(['tag3']);
+        fakeTagsService.filter.resolves([{ text: 'tag3' }]);
         wrapper.find('input').instance().value = 'tag';
         await typeInputAndAwaitResponse(wrapper);
         // suggestions: [tag3]

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -116,7 +116,7 @@ import { FrameSyncService } from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
-import localTagsService from './services/local-tags';
+import { LocalTagsService } from './services/local-tags';
 import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import { ServiceURLService } from './services/service-url';
@@ -162,8 +162,8 @@ function startApp(config, appEl) {
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)
-    .register('tagProvider', localTagsService)
-    .register('tagStore', localTagsService)
+    .register('tagProvider', LocalTagsService)
+    .register('tagStore', LocalTagsService)
     .register('threadsService', ThreadsService)
     .register('toastMessenger', ToastMessengerService)
     .register('store', store);

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -116,6 +116,7 @@ import { FrameSyncService } from './services/frame-sync';
 import groupsService from './services/groups';
 import loadAnnotationsService from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
+import localTagsService from './services/local-tags';
 import { PersistedDefaultsService } from './services/persisted-defaults';
 import { RouterService } from './services/router';
 import { ServiceURLService } from './services/service-url';
@@ -161,6 +162,8 @@ function startApp(config, appEl) {
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)
+    .register('tagProvider', localTagsService)
+    .register('tagStore', localTagsService)
     .register('threadsService', ThreadsService)
     .register('toastMessenger', ToastMessengerService)
     .register('store', store);

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,0 +1,83 @@
+/** @typedef {import('./tags').Tag} Tag */
+
+
+/**
+ * Service for fetching tag suggestions and storing data to generate them.
+ *
+ * The `tags` service stores metadata about recently used tags to local storage
+ * and provides a `filter` method to fetch tags matching a query, ranked based
+ * on frequency of usage.
+ */
+// @inject
+export default function localTags(localStorage) {
+  const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+  const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+  /**
+   * Return a list of tag suggestions matching `query`.
+   *
+   * @param {string} query
+   * @param {number|null} limit - Optional limit of the results.
+   * @return {Tag[]} List of matching tags
+   */
+  function filter(query, limit = null) {
+    const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
+    let resultCount = 0;
+    // query will match tag if:
+    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
+    // * any word in the tag starts with query
+    //   (e.g. tag "pink banana" matches query "ban"), OR
+    // * tag has substring query occurring after a non-word character
+    //   (e.g. tag "pink!banana" matches query "ban")
+    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    return savedTags.filter(tag => {
+      if (tag.match(regex)) {
+        if (limit === null || resultCount < limit) {
+          // limit allows a subset of the results
+          // See https://github.com/hypothesis/client/issues/1606
+          ++resultCount;
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Update the list of stored tag suggestions based on the tags that a user has
+   * entered for a given annotation.
+   *
+   * @param {Tag[]} tags - List of tags.
+   */
+  function store(tags) {
+    // Update the stored (tag, frequency) map.
+    const savedTags = localStorage.getObject(TAGS_MAP_KEY) || {};
+    tags.forEach(tag => {
+      if (savedTags[tag.text]) {
+        savedTags[tag.text].count += 1;
+        savedTags[tag.text].updated = Date.now();
+      } else {
+        savedTags[tag.text] = {
+          text: tag.text,
+          count: 1,
+          updated: Date.now(),
+        };
+      }
+    });
+    localStorage.setObject(TAGS_MAP_KEY, savedTags);
+
+    // Sort tag suggestions by frequency.
+    const tagsList = Object.keys(savedTags).sort((t1, t2) => {
+      if (savedTags[t1].count !== savedTags[t2].count) {
+        return savedTags[t2].count - savedTags[t1].count;
+      }
+      return t1.localeCompare(t2);
+    });
+    localStorage.setObject(TAGS_LIST_KEY, tagsList);
+  }
+
+  return {
+    filter,
+    store,
+  };
+}

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -16,11 +16,12 @@ export default function localTags(localStorage) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
+   * @async
    * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
-   * @return {Tag[]} List of matching tags
+   * @return {Promise<Tag[]>} List of matching tags
    */
-  function filter(query, limit = null) {
+  async function filter(query, limit = null) {
     const savedTags = localStorage.getObject(TAGS_LIST_KEY) || [];
     let resultCount = 0;
     // query will match tag if:
@@ -30,7 +31,7 @@ export default function localTags(localStorage) {
     // * tag has substring query occurring after a non-word character
     //   (e.g. tag "pink!banana" matches query "ban")
     let regex = new RegExp('(\\W|\\b)' + query.text, 'i');
-    return savedTags.filter(tag => {
+    let suggestions = savedTags.filter(tag => {
       if (tag.match(regex)) {
         if (limit === null || resultCount < limit) {
           // limit allows a subset of the results
@@ -41,15 +42,19 @@ export default function localTags(localStorage) {
       }
       return false;
     });
+
+    return Promise.resolve(suggestions);
   }
 
   /**
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
+   * @async
    * @param {Tag[]} tags - List of tags.
+   * @return {Promise}
    */
-  function store(tags) {
+  async function store(tags) {
     // Update the stored (tag, frequency) map.
     const savedTags = localStorage.getObject(TAGS_MAP_KEY) || {};
     tags.forEach(tag => {
@@ -74,6 +79,8 @@ export default function localTags(localStorage) {
       return t1.localeCompare(t2);
     });
     localStorage.setObject(TAGS_LIST_KEY, tagsList);
+
+    return Promise.resolve();
   }
 
   return {

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,4 +1,5 @@
 /** @typedef {import('./tags').Tag} Tag */
+/** @typedef {import('./tags').TagQuery} TagQuery */
 
 /**
  * Service for fetching tag suggestions and storing data to generate them.
@@ -15,7 +16,7 @@ export default function localTags(localStorage) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
-   * @param {string} query
+   * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */
@@ -28,7 +29,7 @@ export default function localTags(localStorage) {
     //   (e.g. tag "pink banana" matches query "ban"), OR
     // * tag has substring query occurring after a non-word character
     //   (e.g. tag "pink!banana" matches query "ban")
-    let regex = new RegExp('(\\W|\\b)' + query, 'i');
+    let regex = new RegExp('(\\W|\\b)' + query.text, 'i');
     return savedTags.filter(tag => {
       if (tag.match(regex)) {
         if (limit === null || resultCount < limit) {

--- a/src/sidebar/services/local-tags.js
+++ b/src/sidebar/services/local-tags.js
@@ -1,6 +1,5 @@
 /** @typedef {import('./tags').Tag} Tag */
 
-
 /**
  * Service for fetching tag suggestions and storing data to generate them.
  *

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -26,11 +26,12 @@ export default function tags(tagProvider, tagStore) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
+   * @async
    * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
-   * @return {Tag[]} List of matching tags
+   * @return {Promise<Tag[]>} List of matching tags
    */
-  function filter(query, limit = null) {
+  async function filter(query, limit = null) {
     return tagProvider.filter(query, limit);
   }
 
@@ -38,9 +39,11 @@ export default function tags(tagProvider, tagStore) {
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
+   * @async
    * @param {Tag[]} tags - List of tags.
+   * @return {Promise}
    */
-  function store(tags) {
+  async function store(tags) {
     return tagStore.store(tags);
   }
 

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -5,86 +5,43 @@
  * @property {number} updated - The timestamp when this tag was last used.
  */
 
-const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
-const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
 
 /**
- * Service for fetching tag suggestions and storing data to generate them.
+ * Service for fetching tag suggestions from a tagProvider service
+ * and storing data for future suggestions.
  *
- * The `tags` service stores metadata about recently used tags to local storage
- * and provides a `filter` method to fetch tags matching a query, ranked based
- * on frequency of usage.
+ * The injected `tagProvider` service needs to provide `filter` method to
+ * fetch tag suggestions matching a query and optional context object.
+ *
+ * The injected `tagStore` service needs to provide a `store`
+ * method to store entered tags.
  */
 // @inject
-export class TagsService {
-  /**
-   * @param {import('./local-storage').LocalStorageService} localStorage -
-   *   Storage used to persist the tags
-   */
-  constructor(localStorage) {
-    this._storage = localStorage;
-  }
+export default function tags(tagProvider, tagStore) {
 
   /**
    * Return a list of tag suggestions matching `query`.
    *
    * @param {string} query
    * @param {number|null} limit - Optional limit of the results.
-   * @return {string[]} List of matching tags
+   * @return {Tag[]} List of matching tags
    */
-  filter(query, limit = null) {
-    const savedTags = this._storage.getObject(TAGS_LIST_KEY) || [];
-    let resultCount = 0;
-    // query will match tag if:
-    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
-    // * any word in the tag starts with query
-    //   (e.g. tag "pink banana" matches query "ban"), OR
-    // * tag has substring query occurring after a non-word character
-    //   (e.g. tag "pink!banana" matches query "ban")
-    let regex = new RegExp('(\\W|\\b)' + query, 'i');
-    return savedTags.filter(tag => {
-      if (tag.match(regex)) {
-        if (limit === null || resultCount < limit) {
-          // limit allows a subset of the results
-          // See https://github.com/hypothesis/client/issues/1606
-          ++resultCount;
-          return true;
-        }
-      }
-      return false;
-    });
+  function filter(query, limit = null) {
+    return tagProvider.filter(query, limit);
   }
 
   /**
    * Update the list of stored tag suggestions based on the tags that a user has
    * entered for a given annotation.
    *
-   * @param {string[]} tags - List of tags.
+   * @param {Tag[]} tags - List of tags.
    */
-  store(tags) {
-    // Update the stored (tag, frequency) map.
-    const savedTags = this._storage.getObject(TAGS_MAP_KEY) || {};
-    tags.forEach(tag => {
-      if (savedTags[tag]) {
-        savedTags[tag].count += 1;
-        savedTags[tag].updated = Date.now();
-      } else {
-        savedTags[tag] = {
-          text: tag,
-          count: 1,
-          updated: Date.now(),
-        };
-      }
-    });
-    this._storage.setObject(TAGS_MAP_KEY, savedTags);
-
-    // Sort tag suggestions by frequency.
-    const tagsList = Object.keys(savedTags).sort((t1, t2) => {
-      if (savedTags[t1].count !== savedTags[t2].count) {
-        return savedTags[t2].count - savedTags[t1].count;
-      }
-      return t1.localeCompare(t2);
-    });
-    this._storage.setObject(TAGS_LIST_KEY, tagsList);
+  function store(tags) {
+    return tagStore.store(tags);
   }
+
+  return {
+    filter,
+    store,
+  };
 }

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -6,8 +6,14 @@
  */
 
 /**
+ * @typedef TagQuery
+ * @property {string} text - The text entered in the tag editor
+ * @property {object|null} context - Optional context object.
+ */
+
+/**
  * Service for fetching tag suggestions from a tagProvider service
- * and storing data for future suggestions.
+ * and optionally storing data to generate them.
  *
  * The injected `tagProvider` service needs to provide `filter` method to
  * fetch tag suggestions matching a query and optional context object.
@@ -20,7 +26,7 @@ export default function tags(tagProvider, tagStore) {
   /**
    * Return a list of tag suggestions matching `query`.
    *
-   * @param {string} query
+   * @param {TagQuery} query
    * @param {number|null} limit - Optional limit of the results.
    * @return {Tag[]} List of matching tags
    */

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -5,7 +5,6 @@
  * @property {number} updated - The timestamp when this tag was last used.
  */
 
-
 /**
  * Service for fetching tag suggestions from a tagProvider service
  * and storing data for future suggestions.
@@ -18,7 +17,6 @@
  */
 // @inject
 export default function tags(tagProvider, tagStore) {
-
   /**
    * Return a list of tag suggestions matching `query`.
    *

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -8,7 +8,7 @@
 /**
  * @typedef TagQuery
  * @property {string} text - The text entered in the tag editor
- * @property {object|null} context - Optional context object.
+ * @property [object] context - Optional context object.
  */
 
 /**
@@ -22,17 +22,26 @@
  * method to store entered tags.
  */
 // @inject
-export default function tags(tagProvider, tagStore) {
+export class TagsService {
+  /**
+   * @param tagProvider - TagProvider implementation
+   * @param tagStore - TagStore implementation
+   */
+  constructor(tagProvider, tagStore) {
+    this._provider = tagProvider;
+    this._store = tagStore;
+  }
+
   /**
    * Return a list of tag suggestions matching `query`.
    *
    * @async
    * @param {TagQuery} query
-   * @param {number|null} limit - Optional limit of the results.
+   * @param [limit] number - Optional limit of the results.
    * @return {Promise<Tag[]>} List of matching tags
    */
-  async function filter(query, limit = null) {
-    return tagProvider.filter(query, limit);
+  async filter(query, limit = null) {
+    return this._provider.filter(query, limit);
   }
 
   /**
@@ -43,12 +52,7 @@ export default function tags(tagProvider, tagStore) {
    * @param {Tag[]} tags - List of tags.
    * @return {Promise}
    */
-  async function store(tags) {
-    return tagStore.store(tags);
+  async store(tags) {
+    return this._store.store(tags);
   }
-
-  return {
-    filter,
-    store,
-  };
 }

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -66,30 +66,29 @@ describe('sidebar/services/tag-provider', () => {
   });
 
   describe('#filter', () => {
-    it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter({ text: 'b' }), [
-        'bar',
-        'bar argon',
-        'banana',
-      ]);
+    it('returns tags that start with the query string', async () => {
+      let suggestions = await tags.filter({ text: 'b' });
+      assert.deepEqual(suggestions, ['bar', 'bar argon', 'banana']);
     });
 
-    it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter({ text: 'ar' }), ['bar argon', 'argon']);
+    it('returns tags that have any word starting with the query string', async () => {
+      let suggestions = await tags.filter({ text: 'ar' });
+      assert.deepEqual(suggestions, ['bar argon', 'argon']);
     });
 
-    it('is case insensitive', () => {
-      assert.deepEqual(tags.filter({ text: 'Ar' }), ['bar argon', 'argon']);
+    it('is case insensitive', async () => {
+      let suggestions = await tags.filter({ text: 'Ar' });
+      assert.deepEqual(suggestions, ['bar argon', 'argon']);
     });
 
-    it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter({ text: 'b' }, 1), ['bar']);
-      assert.deepEqual(tags.filter({ text: 'b' }, 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter({ text: 'b' }, 3), [
-        'bar',
-        'bar argon',
-        'banana',
-      ]);
+    it('limits tags when provided a limit value', async () => {
+      let one = await tags.filter({ text: 'b' }, 1);
+      let two = await tags.filter({ text: 'b' }, 2);
+      let tre = await tags.filter({ text: 'b' }, 3);
+
+      assert.deepEqual(one, ['bar']);
+      assert.deepEqual(two, ['bar', 'bar argon']);
+      assert.deepEqual(tre, ['bar', 'bar argon', 'banana']);
     });
   });
 });

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -1,0 +1,87 @@
+import tagProviderFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-provider', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagProviderFactory(fakeLocalStorage);
+  });
+
+  describe('#filter', () => {
+    it('returns tags that start with the query string', () => {
+      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+    });
+
+    it('returns tags that have any word starting with the query string', () => {
+      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
+    });
+
+    it('is case insensitive', () => {
+      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
+    });
+
+    it('limits tags when provided a limit value', () => {
+      assert.deepEqual(tags.filter('b', 1), ['bar']);
+      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    });
+  });
+});

--- a/src/sidebar/services/test/tag-provider-test.js
+++ b/src/sidebar/services/test/tag-provider-test.js
@@ -67,21 +67,29 @@ describe('sidebar/services/tag-provider', () => {
 
   describe('#filter', () => {
     it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
+      assert.deepEqual(tags.filter({ text: 'b' }), [
+        'bar',
+        'bar argon',
+        'banana',
+      ]);
     });
 
     it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
+      assert.deepEqual(tags.filter({ text: 'ar' }), ['bar argon', 'argon']);
     });
 
     it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
+      assert.deepEqual(tags.filter({ text: 'Ar' }), ['bar argon', 'argon']);
     });
 
     it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('b', 1), ['bar']);
-      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 1), ['bar']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 2), ['bar', 'bar argon']);
+      assert.deepEqual(tags.filter({ text: 'b' }, 3), [
+        'bar',
+        'bar argon',
+        'banana',
+      ]);
     });
   });
 });

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -1,0 +1,108 @@
+import tagStoreFactory from '../local-tags';
+
+const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
+const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+
+class FakeStorage {
+  constructor() {
+    this._storage = {};
+  }
+
+  getObject(key) {
+    return this._storage[key];
+  }
+
+  setObject(key, value) {
+    this._storage[key] = value;
+  }
+}
+
+describe('sidebar/services/tag-store', () => {
+  let fakeLocalStorage;
+  let tags;
+
+  beforeEach(() => {
+    fakeLocalStorage = new FakeStorage();
+
+    const stamp = Date.now();
+    const savedTagsMap = {
+      foo: {
+        text: 'foo',
+        count: 1,
+        updated: stamp,
+      },
+      bar: {
+        text: 'bar',
+        count: 5,
+        updated: stamp,
+      },
+      'bar argon': {
+        text: 'bar argon',
+        count: 2,
+        updated: stamp,
+      },
+      banana: {
+        text: 'banana',
+        count: 2,
+        updated: stamp,
+      },
+      future: {
+        text: 'future',
+        count: 2,
+        updated: stamp,
+      },
+      argon: {
+        text: 'argon',
+        count: 1,
+        updated: stamp,
+      },
+    };
+    const savedTagsList = Object.keys(savedTagsMap);
+
+    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
+    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+
+    tags = tagStoreFactory(fakeLocalStorage);
+  });
+
+  describe('#store', () => {
+    it('saves new tags to storage', () => {
+      tags.store([{ text: 'new' }]);
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.include(storedTagsList, 'new');
+
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.match(
+        storedTagsMap.new,
+        sinon.match({
+          count: 1,
+          text: 'new',
+          updated: sinon.match.number,
+        })
+      );
+    });
+
+    it('increases the count for a tag already stored', () => {
+      tags.store([{ text: 'bar' }]);
+      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
+      assert.equal(storedTagsMap.bar.count, 6);
+    });
+
+    it('orders list by count descending, lexical ascending', () => {
+      for (let i = 0; i < 6; i++) {
+        tags.store([{ text: 'foo' }]);
+      }
+
+      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
+      assert.deepEqual(storedTagsList, [
+        'foo',
+        'bar',
+        'banana',
+        'bar argon',
+        'future',
+        'argon',
+      ]);
+    });
+  });
+});

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -66,8 +66,8 @@ describe('sidebar/services/tag-store', () => {
   });
 
   describe('#store', () => {
-    it('saves new tags to storage', () => {
-      tags.store([{ text: 'new' }]);
+    it('saves new tags to storage', async () => {
+      await tags.store([{ text: 'new' }]);
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
       assert.include(storedTagsList, 'new');
@@ -83,15 +83,15 @@ describe('sidebar/services/tag-store', () => {
       );
     });
 
-    it('increases the count for a tag already stored', () => {
-      tags.store([{ text: 'bar' }]);
+    it('increases the count for a tag already stored', async () => {
+      await tags.store([{ text: 'bar' }]);
       const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
       assert.equal(storedTagsMap.bar.count, 6);
     });
 
-    it('orders list by count descending, lexical ascending', () => {
+    it('orders list by count descending, lexical ascending', async () => {
       for (let i = 0; i < 6; i++) {
-        tags.store([{ text: 'foo' }]);
+        await tags.store([{ text: 'foo' }]);
       }
 
       const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);

--- a/src/sidebar/services/test/tag-store-test.js
+++ b/src/sidebar/services/test/tag-store-test.js
@@ -1,4 +1,4 @@
-import tagStoreFactory from '../local-tags';
+import { LocalTagsService } from '../local-tags';
 
 const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
 const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
@@ -62,7 +62,7 @@ describe('sidebar/services/tag-store', () => {
     fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
     fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
 
-    tags = tagStoreFactory(fakeLocalStorage);
+    tags = new LocalTagsService(fakeLocalStorage);
   });
 
   describe('#store', () => {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -32,7 +32,13 @@ describe('sidebar/services/tags', () => {
 
   describe('#filter', () => {
     it('delegates query call to tag-provider', () => {
-      let query = 'pourquoi';
+      let query = { text: 'pourquoi' };
+      tags.filter(query);
+      return assert.calledWith(fakeTagProvider.filter, query);
+    });
+
+    it('delegates query call to tag-provider with sample context', () => {
+      let query = { text: 'pourquoi', context: { lang: 'fr' } };
       tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,5 +1,4 @@
-import tagsFactory from '../tags';
-import { Injector } from '../../../shared/injector';
+import { TagsService } from '../tags';
 
 let fakeTagProvider;
 let fakeTagStore;
@@ -12,18 +11,14 @@ describe('sidebar/services/tags', () => {
     sandbox = sinon.createSandbox();
 
     fakeTagProvider = {
-      filter: sinon.stub(),
+      filter: sinon.spy(),
     };
 
     fakeTagStore = {
-      store: sinon.stub(),
+      store: sinon.spy(),
     };
 
-    tags = new Injector()
-      .register('tagProvider', { value: fakeTagProvider })
-      .register('tagStore', { value: fakeTagStore })
-      .register('tags', tagsFactory)
-      .get('tags');
+    tags = new TagsService(fakeTagProvider, fakeTagStore);
   });
 
   afterEach(function () {

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -12,17 +12,17 @@ describe('sidebar/services/tags', () => {
     sandbox = sinon.createSandbox();
 
     fakeTagProvider = {
-      filter: sinon.stub()
+      filter: sinon.stub(),
     };
 
     fakeTagStore = {
-      store: sinon.stub()
+      store: sinon.stub(),
     };
 
     tags = new Injector()
       .register('tagProvider', { value: fakeTagProvider })
       .register('tagStore', { value: fakeTagStore })
-      .register( 'tags', tagsFactory)
+      .register('tags', tagsFactory)
       .get('tags');
   });
 

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -1,128 +1,48 @@
-import { TagsService } from '../tags';
+import tagsFactory from '../tags';
+import { Injector } from '../../../shared/injector';
 
-const TAGS_LIST_KEY = 'hypothesis.user.tags.list';
-const TAGS_MAP_KEY = 'hypothesis.user.tags.map';
+let fakeTagProvider;
+let fakeTagStore;
+let sandbox;
 
-class FakeStorage {
-  constructor() {
-    this._storage = {};
-  }
-
-  getObject(key) {
-    return this._storage[key];
-  }
-
-  setObject(key, value) {
-    this._storage[key] = value;
-  }
-}
-
-describe('TagsService', () => {
-  let fakeLocalStorage;
+describe('sidebar/services/tags', () => {
   let tags;
 
   beforeEach(() => {
-    fakeLocalStorage = new FakeStorage();
+    sandbox = sinon.createSandbox();
 
-    const stamp = Date.now();
-    const savedTagsMap = {
-      foo: {
-        text: 'foo',
-        count: 1,
-        updated: stamp,
-      },
-      bar: {
-        text: 'bar',
-        count: 5,
-        updated: stamp,
-      },
-      'bar argon': {
-        text: 'bar argon',
-        count: 2,
-        updated: stamp,
-      },
-      banana: {
-        text: 'banana',
-        count: 2,
-        updated: stamp,
-      },
-      future: {
-        text: 'future',
-        count: 2,
-        updated: stamp,
-      },
-      argon: {
-        text: 'argon',
-        count: 1,
-        updated: stamp,
-      },
+    fakeTagProvider = {
+      filter: sinon.stub()
     };
-    const savedTagsList = Object.keys(savedTagsMap);
 
-    fakeLocalStorage.setObject(TAGS_MAP_KEY, savedTagsMap);
-    fakeLocalStorage.setObject(TAGS_LIST_KEY, savedTagsList);
+    fakeTagStore = {
+      store: sinon.stub()
+    };
 
-    tags = new TagsService(fakeLocalStorage);
+    tags = new Injector()
+      .register('tagProvider', { value: fakeTagProvider })
+      .register('tagStore', { value: fakeTagStore })
+      .register( 'tags', tagsFactory)
+      .get('tags');
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   describe('#filter', () => {
-    it('returns tags that start with the query string', () => {
-      assert.deepEqual(tags.filter('b'), ['bar', 'bar argon', 'banana']);
-    });
-
-    it('returns tags that have any word starting with the query string', () => {
-      assert.deepEqual(tags.filter('ar'), ['bar argon', 'argon']);
-    });
-
-    it('is case insensitive', () => {
-      assert.deepEqual(tags.filter('Ar'), ['bar argon', 'argon']);
-    });
-
-    it('limits tags when provided a limit value', () => {
-      assert.deepEqual(tags.filter('b', 1), ['bar']);
-      assert.deepEqual(tags.filter('b', 2), ['bar', 'bar argon']);
-      assert.deepEqual(tags.filter('b', 3), ['bar', 'bar argon', 'banana']);
+    it('delegates query call to tag-provider', () => {
+      let query = 'pourquoi';
+      tags.filter(query);
+      return assert.calledWith(fakeTagProvider.filter, query);
     });
   });
 
   describe('#store', () => {
-    it('saves new tags to storage', () => {
-      tags.store(['new']);
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.include(storedTagsList, 'new');
-
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.match(
-        storedTagsMap.new,
-        sinon.match({
-          count: 1,
-          text: 'new',
-          updated: sinon.match.number,
-        })
-      );
-    });
-
-    it('increases the count for a tag already stored', () => {
-      tags.store(['bar']);
-      const storedTagsMap = fakeLocalStorage.getObject(TAGS_MAP_KEY);
-      assert.equal(storedTagsMap.bar.count, 6);
-    });
-
-    it('orders list by count descending, lexical ascending', () => {
-      for (let i = 0; i < 6; i++) {
-        tags.store(['foo']);
-      }
-
-      const storedTagsList = fakeLocalStorage.getObject(TAGS_LIST_KEY);
-      assert.deepEqual(storedTagsList, [
-        'foo',
-        'bar',
-        'banana',
-        'bar argon',
-        'future',
-        'argon',
-      ]);
+    it('delegates store call to tag-store', () => {
+      let theTags = [{ text: 'parce que' }];
+      tags.store(theTags);
+      return assert.calledWith(fakeTagStore.store, theTags);
     });
   });
 });

--- a/src/sidebar/services/test/tags-test.js
+++ b/src/sidebar/services/test/tags-test.js
@@ -31,23 +31,23 @@ describe('sidebar/services/tags', () => {
   });
 
   describe('#filter', () => {
-    it('delegates query call to tag-provider', () => {
+    it('delegates query call to tag-provider', async () => {
       let query = { text: 'pourquoi' };
-      tags.filter(query);
+      await tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });
 
-    it('delegates query call to tag-provider with sample context', () => {
+    it('delegates query call to tag-provider with sample context', async () => {
       let query = { text: 'pourquoi', context: { lang: 'fr' } };
-      tags.filter(query);
+      await tags.filter(query);
       return assert.calledWith(fakeTagProvider.filter, query);
     });
   });
 
   describe('#store', () => {
-    it('delegates store call to tag-store', () => {
+    it('delegates store call to tag-store', async () => {
       let theTags = [{ text: 'parce que' }];
-      tags.store(theTags);
+      await tags.store(theTags);
       return assert.calledWith(fakeTagStore.store, theTags);
     });
   });

--- a/src/test-util/accessibility.js
+++ b/src/test-util/accessibility.js
@@ -72,7 +72,7 @@ export function checkAccessibility(scenarios) {
         );
       }
 
-      const elementOrWrapper = content();
+      const elementOrWrapper = await content();
 
       if (
         !(elementOrWrapper instanceof ReactWrapper) &&


### PR DESCRIPTION
This is in preparation for simpler customization of tagProvider
services beyond the current cache implemented in localStorage.

- The tag service now injects a tagProvider and tagStore
- The localStorage implementation has moved to local-tags.js
- local-tags.js is now injected back as both tagProvider and tagStore.
- Introduces a Tag type
- (Preserves existing functionality in client)