### PR TITLE
Remote tag provider service

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -49,5 +49,7 @@ export default function configFrom(window_) {
     externalContainerSelector: settings.hostPageSetting(
       'externalContainerSelector'
     ),
+
+    tagProviderUrl: settings.hostPageSetting('tagProviderUrl'),
   };
 }

--- a/src/sidebar/components/Annotation/AnnotationEditor.js
+++ b/src/sidebar/components/Annotation/AnnotationEditor.js
@@ -106,6 +106,10 @@ function AnnotationEditor({
     return false;
   };
 
+  const onTagSuggestions = suggestions => {
+    return suggestions;
+  };
+
   const onEditText = ({ text }) => {
     store.createDraft(draft.annotation, { ...draft, text });
   };
@@ -152,6 +156,7 @@ function AnnotationEditor({
         onAddTag={onAddTag}
         onRemoveTag={onRemoveTag}
         onTagInput={setPendingTag}
+        onTagSuggestions={onTagSuggestions}
         tagList={tags}
       />
       <div className="annotation__form-actions u-layout-row">

--- a/src/sidebar/components/TagEditor.js
+++ b/src/sidebar/components/TagEditor.js
@@ -67,6 +67,23 @@ function TagEditor({
   };
 
   /**
+   * Helper function that adapts complex suggestions to the "h" expected string
+   *
+   * @param {Tag|string} suggestion
+   */
+  const suggestionText = suggestion => {
+    if (typeof suggestion === 'string') {
+      return suggestion;
+    }
+
+    if (typeof suggestion === 'object' && 'text' in suggestion) {
+      return suggestion.text;
+    }
+
+    return '';
+  };
+
+  /**
    * Helper function that returns a list of suggestions less any
    * results also found from the duplicates list.
    *
@@ -98,7 +115,7 @@ function TagEditor({
       const tags = await tagsService.filter({ text: pendingTag() });
 
       // TRANSFORM (Tag -> string): extract the text fields, removing any empty strings
-      const suggestions = tags.map(t => t.text).filter(s => s);
+      const suggestions = tags.map(suggestionText).filter(s => s);
 
       // Remove any repeated suggestions that are already tags
       // and set those to state.

--- a/src/sidebar/config/host-config.js
+++ b/src/sidebar/config/host-config.js
@@ -58,6 +58,9 @@ export default function hostPageConfig(window) {
     'theme',
 
     'usernameUrl',
+
+    // Endpoint for remote tag provider.
+    'tagProviderUrl',
   ];
 
   // We need to coerce incoming values from the host config for 2 reasons:

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -118,6 +118,7 @@ import { LoadAnnotationsService } from './services/load-annotations';
 import { LocalStorageService } from './services/local-storage';
 import { LocalTagsService } from './services/local-tags';
 import { PersistedDefaultsService } from './services/persisted-defaults';
+import { RemoteTagProviderService } from './services/remote-tag-provider';
 import { RouterService } from './services/router';
 import { ServiceURLService } from './services/service-url';
 import { SessionService } from './services/session';
@@ -162,7 +163,7 @@ function startApp(config, appEl) {
     .register('streamer', streamerService)
     .register('streamFilter', StreamFilter)
     .register('tags', TagsService)
-    .register('tagProvider', LocalTagsService)
+    .register('tagProvider', RemoteTagProviderService)
     .register('tagStore', LocalTagsService)
     .register('threadsService', ThreadsService)
     .register('toastMessenger', ToastMessengerService)

--- a/src/sidebar/services/remote-tag-provider.js
+++ b/src/sidebar/services/remote-tag-provider.js
@@ -1,0 +1,65 @@
+import InsiderTagProviderClient from '../util/insider-tag-provider-client';
+
+/** @typedef {import('./tags').Tag} Tag */
+/** @typedef {import('./tags').TagQuery} TagQuery */
+/** @typedef {import('../util/insider-tag-provider-client').TagProviderAPIResponse} TagProviderAPIResponse */
+
+/**
+ * Service for fetching tag suggestions from a remote endpoint
+ */
+// @inject
+export class RemoteTagProviderService {
+  constructor(settings) {
+    this._tagProviderClient = new InsiderTagProviderClient(settings);
+  }
+
+  /**
+   * Return a list of tag suggestions matching `query`.
+   *
+   * @async
+   * @param {TagQuery} query
+   * @param {number|null} limit - Optional limit of the results.
+   * @return {Promise<Tag[]|null>} List of matching tags
+   */
+  async filter(query, limit = null) {
+    if (!this._tagProviderClient) {
+      return Promise.resolve(null);
+    }
+    // query will match tag if:
+    // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
+    // * any word in the tag starts with query
+    //   (e.g. tag "pink banana" matches query "ban"), OR
+    // * tag has substring query occurring after a non-word character
+    //   (e.g. tag "pink!banana" matches query "ban") (TODO: update index analyzer)
+
+    // TODO: (does this timeout? ... fall back to local-storage? - caller concern?)
+    const resp = await this._tagProviderClient.search(query.text, limit, null);
+    return RemoteTagProviderService.unpackResponseToTagArray(resp);
+  }
+
+  /**
+   * unpackResponseToTagArray
+   *
+   * @param {TagProviderAPIResponse} data
+   * @returns {Tag[]}
+   */
+  static unpackResponseToTagArray(data) {
+    const { /* query, query_ms,*/ concepts } = data;
+    return concepts.map(RemoteTagProviderService.unpackConceptToTag);
+  }
+
+  /**
+   * unpackConceptToTag
+   *
+   * @param concept
+   * @returns {Tag}
+   */
+  static unpackConceptToTag(concept) {
+    return {
+      text: concept?.label,
+      scope: concept?.scheme,
+      count: concept?.count,
+      updated: concept?.updated,
+    };
+  }
+}

--- a/src/sidebar/services/remote-tag-provider.js
+++ b/src/sidebar/services/remote-tag-provider.js
@@ -67,9 +67,9 @@ export class RemoteTagProviderService {
   static unpackConceptToTag(concept) {
     return {
       text: concept?.label,
-      scope: concept?.scheme,
       count: concept?.count,
       updated: concept?.updated,
+      scope: concept?.scheme,
     };
   }
 }

--- a/src/sidebar/services/remote-tag-provider.js
+++ b/src/sidebar/services/remote-tag-provider.js
@@ -25,6 +25,11 @@ export class RemoteTagProviderService {
     if (!this._tagProviderClient) {
       return Promise.resolve(null);
     }
+
+    if (!query || !('text' in query) || query.text.trim() === '') {
+      return Promise.resolve(null)
+    }
+
     // query will match tag if:
     // * tag starts with query (e.g. tag "banana" matches query "ban"), OR
     // * any word in the tag starts with query
@@ -33,7 +38,12 @@ export class RemoteTagProviderService {
     //   (e.g. tag "pink!banana" matches query "ban") (TODO: update index analyzer)
 
     // TODO: (does this timeout? ... fall back to local-storage? - caller concern?)
-    const resp = await this._tagProviderClient.search(query.text, limit, null);
+    const resp = await this._tagProviderClient.search(
+      query.text.toLowerCase(),
+      limit,
+      null
+    );
+
     return RemoteTagProviderService.unpackResponseToTagArray(resp);
   }
 

--- a/src/sidebar/services/remote-tag-provider.js
+++ b/src/sidebar/services/remote-tag-provider.js
@@ -27,7 +27,7 @@ export class RemoteTagProviderService {
     }
 
     if (!query || !('text' in query) || query.text.trim() === '') {
-      return Promise.resolve(null)
+      return Promise.resolve(null);
     }
 
     // query will match tag if:

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -3,13 +3,13 @@
  * @property {string} text - The label of the tag
  * @property {number} count - The number of times this tag has been used.
  * @property {number} updated - The timestamp when this tag was last used.
- * @property {string|undefined} scope - Optional scope descriptor
+ * @property {string} [scope] - Optional scope descriptor.
  */
 
 /**
  * @typedef TagQuery
  * @property {string} text - The text entered in the tag editor
- * @property [object] context - Optional context object.
+ * @property {object} [context] - Optional context object.
  */
 
 /**

--- a/src/sidebar/services/tags.js
+++ b/src/sidebar/services/tags.js
@@ -3,6 +3,7 @@
  * @property {string} text - The label of the tag
  * @property {number} count - The number of times this tag has been used.
  * @property {number} updated - The timestamp when this tag was last used.
+ * @property {string|undefined} scope - Optional scope descriptor
  */
 
 /**

--- a/src/sidebar/util/insider-tag-provider-client.js
+++ b/src/sidebar/util/insider-tag-provider-client.js
@@ -1,5 +1,3 @@
-import * as queryString from 'query-string';
-
 /**
  * @typedef TagProviderAPIResponseQuery
  * @property {string} text - The text query sent to the API
@@ -60,27 +58,28 @@ export default class InsiderTagProviderClient {
       this.tagSearchEndpoint.replace(/^\//, ''),
     ].join('/');
 
-    return this._get(
+    return this._request(
       urlWithEndpoint,
       Object.assign({ text }, limit && { limit }, schemes && { schemes })
     );
   }
 
   /**
-   * Make an `application/json` GET request.
+   * Make an `application/json` POST request to elasticsearch.
    *
    * @param {string} url
    * @param {object} data - Parameter dictionary
    */
-  async _get(url, data) {
-    const qs = queryString.stringify(data);
-    const requestUrl = [url, qs].join('?');
-
-    return fetch(requestUrl).then(response => {
+  async _request(url, data) {
+    return fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    }).then(response => {
       if (!response.ok) {
         throw new Error('HTTP error, status = ' + response.status);
       }
-      return response.json();
+      return response.json().then(r => r.body);
     });
   }
 }

--- a/src/sidebar/util/insider-tag-provider-client.js
+++ b/src/sidebar/util/insider-tag-provider-client.js
@@ -1,0 +1,86 @@
+import * as queryString from 'query-string';
+
+/**
+ * @typedef TagProviderAPIResponseQuery
+ * @property {string} text - The text query sent to the API
+ * @property {number} size - The number of tag suggestions requested from the API
+ */
+
+/**
+ * @typedef TagProviderAPIResponseConcept
+ * @property {string} label - The label of the tag
+ * @property {string} scheme - The scheme or taxonomy where this tag lives
+ * @property {string} uri - The canonical uri identifying this tag
+ * @property {number} count - The number of times this tag has been used.
+ * @property {number} updated - The timestamp when this tag was last used.
+ */
+
+/**
+ * @typedef TagProviderAPIResponse
+ * @property {TagProviderAPIResponseQuery} query - The query structure sent
+ * @property {number} query_ms - The lookup time
+ * @property {TagProviderAPIResponseConcept[]} concepts - The list of concepts found
+ */
+
+/**
+ * TagProviderClient configuration.
+ *
+ * @typedef {Object} Config
+ * @property {string} tagProviderUrl - Url for tag provider api endpoints
+ * @property {string|undefined} tagSearchEndpoint - search endpoint
+ * @property {string|undefined} tagSuggestEndpoint - suggest endpoint
+ */
+
+/**
+ * TagProviderClient handles interaction with a tag provider endpoint
+ */
+export default class InsiderTagProviderClient {
+  /**
+   * Create a new TagProviderClient
+   *
+   * @param {Config} config
+   */
+  constructor(config) {
+    this.tagProviderUrl = config.tagProviderUrl;
+    this.tagSearchEndpoint = config.tagSearchEndpoint || '/search';
+    this.tagSuggestEndpoint = config.tagSuggestEndpoint || '/suggest';
+  }
+
+  /**
+   * Search for existing tags given a tag name or prefix
+   *
+   * @param {string} text - Tag name or prefix
+   * @param {number|null} limit - Maximum number of results to return
+   * @param {String[]|null} schemes - Limit to certain schemes / taxonomies
+   * @returns {Promise<TagProviderAPIResponse>}
+   */
+  async search(text, limit, schemes) {
+    const urlWithEndpoint = [
+      this.tagProviderUrl.replace(/\/$/, ''),
+      this.tagSearchEndpoint.replace(/^\//, ''),
+    ].join('/');
+
+    return this._get(
+      urlWithEndpoint,
+      Object.assign({ text }, limit && { limit }, schemes && { schemes })
+    );
+  }
+
+  /**
+   * Make an `application/json` GET request.
+   *
+   * @param {string} url
+   * @param {object} data - Parameter dictionary
+   */
+  async _get(url, data) {
+    const qs = queryString.stringify(data);
+    const requestUrl = [url, qs].join('?');
+
+    return fetch(requestUrl).then(response => {
+      if (!response.ok) {
+        throw new Error('HTTP error, status = ' + response.status);
+      }
+      return response.json();
+    });
+  }
+}

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -50,6 +50,7 @@
  * @prop {string[]} rpcAllowedOrigins
  * @prop {SentryConfig} [sentry]
  * @prop {string} [websocketUrl]
+ * @prop {string} tagProviderUrl
  */
 
 /**


### PR DESCRIPTION
Implements remote tag provider service pointing to tag serving endpoint `/search`.